### PR TITLE
module 5 - Fix connection terminated error after resetting db

### DIFF
--- a/module-5/README.md
+++ b/module-5/README.md
@@ -110,6 +110,12 @@ void contextLoads() {
 @BeforeEach
 public void reset() {
     pg.reset();
+    // Resetting the database terminates the connections, so we need to soft-evict those in the connection pool as well.
+    // Otherwise, tests would fail with postgres error 'FATAL: terminating connection due to administrator command'.
+    DataSource dataSource = jdbcTemplate.getDataSource();
+    if (dataSource instanceof HikariDataSource hikariDataSource) {
+        hikariDataSource.getHikariPoolMXBean().softEvictConnections();
+    }
 }
 ```
 


### PR DESCRIPTION
Just had the workshop at the Spring.IO 2024 and was facing this error:

```
org.springframework.dao.DataAccessResourceFailureException: StatementCallback; SQL [SELECT current_database();]; FATAL: terminating connection due to administrator command

	at org.springframework.jdbc.support.SQLStateSQLExceptionTranslator.doTranslate(SQLStateSQLExceptionTranslator.java:121)
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:107)
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:116)
	at org.springframework.jdbc.core.JdbcTemplate.translateException(JdbcTemplate.java:1548)
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:408)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:476)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:486)
	at org.springframework.jdbc.core.JdbcTemplate.queryForObject(JdbcTemplate.java:519)
	at org.springframework.jdbc.core.JdbcTemplate.queryForObject(JdbcTemplate.java:526)
	at org.testcontainers.containers.PostgresWithTemplatesTest.contextLoads(PostgresWithTemplatesTest.java:48)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

Seem to have fixed it with this workaround and thought it may be handy for others to share.

Fix:
If calling reset() on the container, all existing db connections are terminated.
Soft-evict them in the HikcariCP pool to avoid errors when running the tests afterwards.